### PR TITLE
Prevent picking the wrong BlockState when MMB is clicked

### DIFF
--- a/src/main/java/nl/lelebees/betterslabs/mixin/BlockPlacementMixin.java
+++ b/src/main/java/nl/lelebees/betterslabs/mixin/BlockPlacementMixin.java
@@ -20,7 +20,7 @@ public class BlockPlacementMixin {
     @Inject(method = "placeBlock", at = @At("HEAD"))
     private void injected(World world, BlockState targetBlockState, BlockPosition blockPos, double timeSinceLastInteract, CallbackInfo ci, @Local LocalRef<BlockState> blockStateLocalRef) {
         BlockState blockState = blockStateLocalRef.get();
-        if (!blockState.stringId.contains("vertical")) {
+        if (!blockState.stringId.contains("type=vertical")) {
             return;
         }
         String newOrientation = ViewDirection.getViewDirection(InGame.getLocalPlayer().getEntity()).getOrientation();

--- a/src/main/java/nl/lelebees/betterslabs/mixin/HotbarMixin.java
+++ b/src/main/java/nl/lelebees/betterslabs/mixin/HotbarMixin.java
@@ -1,0 +1,37 @@
+package nl.lelebees.betterslabs.mixin;
+
+import com.llamalad7.mixinextras.sugar.Local;
+import com.llamalad7.mixinextras.sugar.ref.LocalRef;
+import finalforeach.cosmicreach.ui.Hotbar;
+import finalforeach.cosmicreach.world.blocks.BlockState;
+import nl.lelebees.betterslabs.extras.ViewDirection;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(Hotbar.class)
+public class HotbarMixin {
+
+    @Inject(method = "pickBlock", at = @At("HEAD"))
+    private void blockSlabPicks(BlockState blockState, CallbackInfo ci, @Local LocalRef<BlockState> blockStateLocalRef) {
+        BlockState targetBlock = blockStateLocalRef.get();
+        if (!targetBlock.stringId.contains("type=vertical")) {
+            return;
+        }
+        String orientation = ViewDirection.WEST.getOrientation();
+        // TODO: YAY! reusable code!
+        String[] blockStateId = targetBlock.stringId.split("=");
+        StringBuilder stateIdBuilder = new StringBuilder();
+        for (String string : blockStateId) {
+            if (string.equals(blockStateId[blockStateId.length - 1])) {
+                stateIdBuilder.append(orientation);
+                continue;
+            }
+            stateIdBuilder.append(string).append("=");
+        }
+        String saveKey = targetBlock.getBlockId() + "[" + stateIdBuilder + "]";
+        targetBlock = BlockState.getInstance(saveKey);
+        blockStateLocalRef.set(targetBlock);
+    }
+}

--- a/src/main/java/nl/lelebees/betterslabs/mixin/ItemCatalogMixin.java
+++ b/src/main/java/nl/lelebees/betterslabs/mixin/ItemCatalogMixin.java
@@ -6,6 +6,7 @@ import com.llamalad7.mixinextras.sugar.Local;
 import finalforeach.cosmicreach.items.ItemStack;
 import finalforeach.cosmicreach.ui.ItemCatalog;
 import finalforeach.cosmicreach.world.blocks.BlockState;
+import nl.lelebees.betterslabs.extras.ViewDirection;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 
@@ -14,7 +15,7 @@ public class ItemCatalogMixin {
 
     @WrapOperation(method = "<init>", at = @At(value = "INVOKE", target = "Lfinalforeach/cosmicreach/ui/ItemCatalog;addItemStack(Lfinalforeach/cosmicreach/items/ItemStack;)Z"))
     private boolean excludeMultipleVerticalSlabs(ItemCatalog instance, ItemStack itemStack, Operation<Boolean> original, @Local BlockState state) {
-        if (state.stringId.contains("slab_type=vertical") && !state.stringId.contains("verticalNegZ")) {
+        if (state.stringId.contains("type=vertical") && !state.stringId.contains(ViewDirection.WEST.getOrientation())) {
             return false;
         }
         return original.call(instance, itemStack);

--- a/src/main/resources/betterslabs.mixins.json
+++ b/src/main/resources/betterslabs.mixins.json
@@ -5,6 +5,7 @@
   "compatibilityLevel": "JAVA_17",
   "mixins": [
     "BlockPlacementMixin",
+    "HotbarMixin",
     "ItemCatalogMixin"
   ],
   "client": [],


### PR DESCRIPTION
This PR fixes a bug where you would still be given the original blockstate of a block instead of it's singular representation.

closes #2 